### PR TITLE
added dynamic fields

### DIFF
--- a/config/discountify.php
+++ b/config/discountify.php
@@ -3,4 +3,8 @@
 return [
     'global_discount' => 0,
     'global_tax_rate' => 0,
+    'fields' => [
+        'quantity' => 'quantity',
+        'price' => 'price',
+    ],
 ];

--- a/src/Concerns/HasCalculations.php
+++ b/src/Concerns/HasCalculations.php
@@ -65,7 +65,7 @@ trait HasCalculations
         return array_reduce(
             $this->items,
             function ($total, $item) {
-                return $total + ($item['quantity'] * $item['price']);
+                return $total + ($this->getField($item, 'quantity') * $this->getField($item, 'price'));
             },
             0
         );

--- a/src/Concerns/HasDynamicFields.php
+++ b/src/Concerns/HasDynamicFields.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Safemood\Discountify\Concerns;
+
+/**
+ * Trait HasDynamicFields
+ */
+trait HasDynamicFields
+{
+    protected $dynamicFields = [];
+
+    /**
+     * Set a single dynamic field mapping.
+     */
+    public function setField(string $fieldName, string $fieldKey): self
+    {
+        $this->dynamicFields[$fieldName] = $fieldKey;
+
+        return $this;
+    }
+
+    /**
+     * Set multiple dynamic field mappings.
+     */
+    public function setFields(array $fields): self
+    {
+        foreach ($fields as $fieldName => $fieldKey) {
+            $this->setField($fieldName, $fieldKey);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get all dynamic field mappings.
+     */
+    public function getFields(): array
+    {
+        return $this->dynamicFields;
+    }
+
+    /**
+     * Get the value of a dynamic field for a given item.
+     */
+    protected function getField(array $item, string $fieldName)
+    {
+        $fieldMapping = $this->dynamicFields + $this->getDefaultFields();
+
+        $fieldKey = $fieldMapping[$fieldName] ?? null;
+
+        if ($fieldKey !== null) {
+            return $item[$fieldKey] ?? null;
+        }
+
+        return $item[$fieldName] ?? null;
+    }
+
+    /**
+     * Get the default dynamic field configuration from the package's configuration.
+     */
+    protected function getDefaultFields(): array
+    {
+        return config('discountify.fields', []);
+    }
+}

--- a/src/Discountify.php
+++ b/src/Discountify.php
@@ -3,6 +3,7 @@
 namespace Safemood\Discountify;
 
 use Safemood\Discountify\Concerns\HasCalculations;
+use Safemood\Discountify\Concerns\HasDynamicFields;
 use Safemood\Discountify\Contracts\DiscountifyInterface;
 
 /**
@@ -19,10 +20,12 @@ use Safemood\Discountify\Contracts\DiscountifyInterface;
  * @method float total()
  * @method float totalWithDiscount(?float $globalDiscount = null)
  * @method self discount(float $globalDiscount)
+ * @method self setFields(array $fields)
  */
 class Discountify implements DiscountifyInterface
 {
     use HasCalculations;
+    use HasDynamicFields;
 
     protected array $items;
 

--- a/src/DiscountifyServiceProvider.php
+++ b/src/DiscountifyServiceProvider.php
@@ -17,7 +17,7 @@ class DiscountifyServiceProvider extends PackageServiceProvider
             ->hasCommand(DiscountifyCommand::class);
     }
 
-    public function bootingPackage()
+    public function packageRegistered()
     {
         $this->app->singleton(ConditionManager::class, function () {
             return new ConditionManager();

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
 use Safemood\Discountify\ConditionManager;
 use Safemood\Discountify\Discountify;
 use Safemood\Discountify\Facades\Condition;
@@ -144,4 +145,51 @@ it('can use Discountify facade', function () {
     expect($totalWithDiscount)->toBe(floatval(170));
     expect($totalWithTaxes)->toBe(floatval(238));
     expect($taxRate)->toBe(floatval(38));
+});
+
+it('calculates total with discount using custom field names from configuration', function () {
+    Config::set('discountify.fields', [
+        'price' => 'amount',
+        'quantity' => 'qty',
+    ]);
+
+    $items = [
+        ['id' => 'item1', 'qty' => 2, 'amount' => 20],
+        ['id' => 'item2', 'qty' => 1, 'amount' => 20],
+    ];
+
+    $this->discountify->setItems($items);
+
+    $totalWithDiscount = $this->discountify->totalWithDiscount(50);
+
+    expect($totalWithDiscount)->toBe(floatval(30));
+});
+
+it('calculates total with discount using dynamically set custom field names', function () {
+    $items = [
+        ['id' => 'item1', 'qty' => 2, 'amount' => 20],
+        ['id' => 'item2', 'qty' => 1, 'amount' => 20],
+    ];
+
+    $this->discountify->setFields([
+        'price' => 'amount',
+        'quantity' => 'qty',
+    ])->setItems($items);
+
+    $totalWithDiscount = $this->discountify->totalWithDiscount(50);
+
+    expect($totalWithDiscount)->toBe(floatval(30));
+});
+
+it('calculates total with discount using dynamically set custom price field name', function () {
+    $items = [
+        ['id' => 'item1', 'quantity' => 2, 'amount' => 20],
+        ['id' => 'item2', 'quantity' => 1, 'amount' => 20],
+    ];
+
+    $this->discountify->setField('price', 'amount')->setItems($items);
+
+    $totalWithDiscount = $this->discountify->totalWithDiscount(50);
+
+    expect($totalWithDiscount)->toBe(floatval(30));
 });


### PR DESCRIPTION
Feature Description:

This pull request introduces enhanced flexibility to the Discountify package by allowing users to dynamically define custom field names for essential cart properties such as "price" and "quantity." The update enables users to configure these field mappings both statically through the configuration file and dynamically during runtime.

Key Changes:

Users can now configure custom field names for "price" and "quantity" in the discountify.php configuration file.
A new setFields method is introduced to dynamically set custom field names during runtime.
The package gracefully handles cases where not all custom fields are defined by falling back to default configurations.
Use Cases:

Custom Field Names from Configuration:

```php
// config/discountify.php
return [
    'global_discount' => 0,
    'global_tax_rate' => 0,
    'fields' => [
        'quantity' => 'quantity',
        'price' => 'price',
    ],
];
```

```php
$items = [
    ['id' => 'item1', 'qty' => 2, 'amount' => 20],
    ['id' => 'item2', 'qty' => 1, 'amount' => 20],
];

$this->discountify->setItems($items);
$totalWithDiscount = $this->discountify->totalWithDiscount(50);
```

Dynamic Custom Field Names:

```php
$items = [
    ['id' => 'item1', 'qty' => 2, 'amount' => 20],
    ['id' => 'item2', 'qty' => 1, 'amount' => 20],
];

$this->discountify->setFields([
    'price' => 'amount',
    'quantity' => 'qty',
])->setItems($items);

$totalWithDiscount = $this->discountify->totalWithDiscount(50);
```
These enhancements empower users to adapt the Discountify package to various cart structures and naming conventions, making it more versatile and user-friendly.