### PR TITLE
feat: Add slug parameter to define and defineIf methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Discountify is a Laravel package designed for managing dynamic discounts with cu
   - [Set Items, Global Discount, and Tax Rate](#set-items-global-discount-and-tax-rate)
   - [Calculate Total Amounts](#calculate-total-amounts)
   - [Dynamic Field Names](#dynamic-field-names)
-  - [Named Discounts](#named-discounts)
-  - [Event Tracking](#event-tracking)
+  - [Skip Discounts Condistions](#skip-discounts-condistions)
   - [Class-Based Discounts](#class-based-discounts)
+  - [Event Tracking](#event-tracking)
 
 ## Installation
 
@@ -58,11 +58,12 @@ class AppServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        // If items are more than 2, apply a 20% discount.
-        Condition::define(fn (array $items) => count($items) > 2, 20)
+        // If items are more than 2, apply a 10% discount.
+        Condition::define('more_than_2_products_10', fn (array $items) => count($items) > 2, 10)
             // If the date is within a 7-day interval starting March 1, 2024, apply a 15% discount.
             ->add([
                 [
+                    'slug' => 'more_than_3_products_15',
                     'condition' => fn ($items) => now()->between(
                         Carbon::createFromDate(2024, 3, 1),
                         Carbon::createFromDate(2024, 3, 15)->addDays(7)
@@ -71,12 +72,13 @@ class AppServiceProvider extends ServiceProvider
                 ],
                 // If 'special' items are in the cart, apply a 10% discount.
                 [
+                    'slug' => 'special_type_product_10',
                     'condition' => fn ($items) => in_array('special', array_column($items, 'type')),
                     'discount' => 10,
                 ],
             ])
             // If the user has a renewal, apply a 10% discount.
-            ->defineIf(auth()->user()->hasRenewal(), 10);
+            ->defineIf('client_has_renewal_10', auth()->user()->hasRenewal(), 10);
     }
 }
 ```
@@ -145,15 +147,15 @@ $totalWithDiscount = $discountify->totalWithDiscount(50);
 
 ```
 
-### Named Discounts
+### Class-Based Discounts
+Explore complex logic with classes (working on it)
 
-Identify and manage with user-friendly names. (working on it)
+### Skip Discounts Condistions
+
+The ability to skip some conditions if needed. (working on it)
 
 ### Event Tracking
 Know when a discount is applied with customizable events. (working on it)
-
-### Class-Based Discounts
-Explore complex logic with classes (working on it)
 
 ## Testing
 

--- a/src/ConditionManager.php
+++ b/src/ConditionManager.php
@@ -2,6 +2,7 @@
 
 namespace Safemood\Discountify;
 
+use InvalidArgumentException;
 use Safemood\Discountify\Contracts\ConditionManagerInterface;
 
 /**
@@ -16,7 +17,7 @@ class ConditionManager implements ConditionManagerInterface
      *
      * @return $this
      */
-    public function add(array $conditions)
+    public function add(array $conditions): self
     {
         $this->conditions = array_merge($this->conditions, $conditions);
 
@@ -28,9 +29,13 @@ class ConditionManager implements ConditionManagerInterface
      *
      * @return $this
      */
-    public function define(callable $condition, float $discountPercentage)
+    public function define(string $slug, callable $condition, float $discountPercentage): self
     {
-        $this->conditions[] = ['condition' => $condition, 'discount' => $discountPercentage];
+        if (empty($slug)) {
+            throw new InvalidArgumentException('Slug must be provided.');
+        }
+
+        $this->conditions[] = compact('slug', 'condition', 'discountPercentage');
 
         return $this;
     }
@@ -40,11 +45,9 @@ class ConditionManager implements ConditionManagerInterface
      *
      * @return $this
      */
-    public function defineIf(bool $condition, float $discountPercentage)
+    public function defineIf(string $slug, bool $isAcceptable, float $discountPercentage): self
     {
-        $this->conditions[] = ['condition' => $condition, 'discount' => $discountPercentage];
-
-        return $this;
+        return $this->define($slug, fn () => $isAcceptable, $discountPercentage);
     }
 
     /**

--- a/src/Contracts/ConditionManagerInterface.php
+++ b/src/Contracts/ConditionManagerInterface.php
@@ -2,13 +2,15 @@
 
 namespace Safemood\Discountify\Contracts;
 
+use Safemood\Discountify\ConditionManager;
+
 interface ConditionManagerInterface
 {
-    public function add(array $conditions);
+    public function add(array $conditions): ConditionManager;
 
-    public function define(callable $condition, float $discountPercentage);
+    public function define(string $slug, callable $condition, float $discountPercentage): ConditionManager;
 
-    public function defineIf(bool $condition, float $discountPercentage);
+    public function defineIf(string $slug, bool $condition, float $discountPercentage): ConditionManager;
 
     public function getConditions(): array;
 }

--- a/src/Facades/Condition.php
+++ b/src/Facades/Condition.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Facades\Facade;
  * Class Condition
  *
  * @method static \Safemood\Discountify\ConditionManager add(array $conditions)
- * @method static \Safemood\Discountify\ConditionManager define(callable $condition, float $discountPercentage)
- * @method static \Safemood\Discountify\ConditionManager defineIf(bool $condition, float $discountPercentage)
+ * @method static \Safemood\Discountify\ConditionManager define(string $slug, callable $condition, float $discountPercentage)
+ * @method static \Safemood\Discountify\ConditionManager defineIf(string $slug,bool $condition, float $discountPercentage)
  * @method static array getConditions()
  * @method static array getItems()
  *

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -92,18 +92,20 @@ it('can get subtotal', function () {
 it('can add conditions using ConditionManager', function () {
     $conditionManager = new ConditionManager();
     $conditionManager
-        ->define(fn (array $items) => count($items) > 2, 20)
+        ->define('more_than_2_products_10', fn (array $items) => count($items) > 2, 10)
         ->add([
             [
+                'slug' => 'more_than_3_products_15',
                 'condition' => fn ($items) => count($items) > 3,
                 'discount' => 15,
             ],
             [
+                'slug' => 'special_type_product_10',
                 'condition' => fn ($items) => in_array('special', array_column($items, 'type')),
                 'discount' => 10,
             ],
         ])
-        ->defineIf(true, 10);
+        ->defineIf('client_has_renewal_10', true, 10);
 
     $conditions = $conditionManager->getConditions();
 
@@ -112,18 +114,20 @@ it('can add conditions using ConditionManager', function () {
 
 it('can use Condition facade', function () {
 
-    Condition::define(fn (array $items) => count($items) > 2, 20)
+    Condition::define('more_than_2_products_10', fn (array $items) => count($items) > 2, 10)
         ->add([
             [
+                'slug' => 'more_than_3_products_15',
                 'condition' => fn ($items) => count($items) > 3,
                 'discount' => 15,
             ],
             [
+                'slug' => 'special_type_product_10',
                 'condition' => fn ($items) => in_array('special', array_column($items, 'type')),
                 'discount' => 10,
             ],
         ])
-        ->defineIf(true, 10);
+        ->defineIf('client_has_renewal_10', true, 10);
 
     $conditions = DiscountifyFacade::getConditions();
 
@@ -192,4 +196,14 @@ it('calculates total with discount using dynamically set custom price field name
     $totalWithDiscount = $this->discountify->totalWithDiscount(50);
 
     expect($totalWithDiscount)->toBe(floatval(30));
+});
+
+it('throws exception when slug is not provided in define method', function () {
+    expect(fn () => Condition::define('', fn ($items) => count($items) > 5, 10))
+        ->toThrow(Exception::class, 'Slug must be provided.');
+});
+
+it('throws exception when slug is not provided in defineIf method', function () {
+    expect(fn () => Condition::defineIf('', true, 10))
+        ->toThrow(Exception::class, 'Slug must be provided.');
 });


### PR DESCRIPTION
## Summary
This pull request introduces a feature enhancement to the `Discountify` class, specifically focusing on the `define` and `defineIf` methods. The enhancement involves the addition of the `slug` parameter to these methods, allowing users to specify a unique identifier for each defined condition.

## Changes Made
- Added the `slug` parameter to the `define` method, enabling users to provide a distinct identifier for the condition.
- Extended the enhancement to the `defineIf` method, incorporating the `slug` parameter for consistent functionality.

## Usage Example
```php
// Example using define method
$discountify->define('more_than_5_products_10', function ($items) {
    // condition logic
    return count($items) > 5;
}, 10);

// Example using defineIf method
$discountify->defineIf('more_than_5_products_10', auth()->user()->hasRenewal(), 10);
