### PR TITLE
Added the ability to skip conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,41 @@ class MoreThan1ProductsCondition implements ConditionInterface
 
 ### Skip Discounts Conditions
 
-The ability to skip some conditions if needed. (working on it)
+This will allows you to exclude specific conditions based on the "skip" field.
+
+Using ConditionManager::define:
+
+```php
+Condition::define('condition2', fn ($items) => false, 20, true);  // Will be skipped
+```
+
+- Using Condition::add:
+```php
+Condition::add([
+    ['slug' => 'condition1', 'condition' => fn ($items) => true, 'discount' => 10, 'skip' => false],  // Won't be skipped
+    ['slug' => 'condition2', 'condition' => fn ($items) => false, 'discount' => 20, 'skip' => true], // Will be skipped
+    ['slug' => 'condition3', 'condition' => fn ($items) => true, 'discount' => 30], // Will not be skipped (default skip is false)
+]);
+```
+- Using  Class-Based Conditions:
+
+```php
+namespace App\Conditions;
+
+use Safemood\Discountify\Contracts\ConditionInterface;
+
+class ExampleCondition implements ConditionInterface
+{
+    public bool $skip = true; // Set to true to skip the condition
+
+    public string $slug = 'skipped_condition';
+
+    public function __invoke(array $items): bool
+    {
+         return count($items) > 5;
+    }
+}
+```
 
 ### Event Tracking
 Know when a discount is applied with customizable events. (working on it)

--- a/src/Contracts/ConditionManagerInterface.php
+++ b/src/Contracts/ConditionManagerInterface.php
@@ -8,7 +8,7 @@ interface ConditionManagerInterface
 {
     public function add(array $conditions): ConditionManager;
 
-    public function define(string $slug, callable $condition, float $discount): ConditionManager;
+    public function define(string $slug, callable $condition, float $discount, bool $skip = false): ConditionManager;
 
     public function defineIf(string $slug, bool $condition, float $discount): ConditionManager;
 

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -259,3 +259,40 @@ it('can work correctly with class-based conditions', function () {
     expect($totalWithTaxes)->toBe(floatval(238));
     expect($taxRate)->toBe(floatval(38));
 });
+
+test('it skips conditions marked with "skip"', function () {
+
+    $conditions = [
+        ['slug' => 'condition_1', 'condition' => fn () => true, 'discount' => 10],
+        ['slug' => 'condition_2', 'condition' => fn () => false, 'discount' => 20, 'skip' => true],
+        ['slug' => 'condition_3', 'condition' => fn () => true, 'discount' => 30, 'skip' => false],
+    ];
+
+    Condition::add($conditions);
+
+    $finalConditions = Condition::getConditions();
+
+    $this->assertCount(2, $finalConditions);
+});
+
+test('it throws an exception for conditions without "slug"', function () {
+    $this->expectException(InvalidArgumentException::class);
+
+    $conditions = [
+        ['condition' => fn () => true, 'discount' => 10],
+    ];
+
+    Condition::add($conditions);
+});
+
+test('it skips class-based conditions marked with "skip"', function () {
+
+    Condition::discover(
+        'Workbench\\App\\Conditions',
+        workbench_path('app/Conditions')
+    );
+
+    $conditions = Condition::getConditions();
+
+    expect($conditions)->toHaveCount(2);
+});

--- a/workbench/app/Conditions/SkippedCondition.php
+++ b/workbench/app/Conditions/SkippedCondition.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Workbench\App\Conditions;
+
+use Safemood\Discountify\Contracts\ConditionInterface;
+
+class SkippedCondition implements ConditionInterface
+{
+    public bool $skip = true;
+
+    public string $slug = 'skipped_condition';
+
+    public int $discount = 40;
+
+    public function __invoke(array $items): bool
+    {
+        return in_array('special', array_column($items, 'type'));
+    }
+}


### PR DESCRIPTION

Introduces a skip feature to Discountify for excluding conditions marked with "skip". Enhances configurability and control over condition processing.

### Changes Made

- Implemented skip feature in `ConditionManager`.
- Modified `add` method for excluding conditions marked for skipping.
- Improved error handling for better exception messages.

### Usage
Using ConditionManager::define:

```php
Condition::define('condition2', fn ($items) => false, 20, true);  // Will be skipped
```

- Using Condition::add:
```php
Condition::add([
    ['slug' => 'condition1', 'condition' => fn ($items) => true, 'discount' => 10, 'skip' => false],  // Won't be skipped
    ['slug' => 'condition2', 'condition' => fn ($items) => false, 'discount' => 20, 'skip' => true], // Will be skipped
    ['slug' => 'condition3', 'condition' => fn ($items) => true, 'discount' => 30], // Will not be skipped (default skip is false)
]);
```
- Using  Class-Based Conditions:

```php
namespace App\Conditions;

use Safemood\Discountify\Contracts\ConditionInterface;

class ExampleCondition implements ConditionInterface
{
    public bool $skip = true; // Set to true to skip the condition

    public string $slug = 'skipped_condition';

    public function __invoke(array $items): bool
    {
         return count($items) > 5;
    }
}
```