### PR TITLE
Fix duplicates conditions

### DIFF
--- a/src/ConditionManager.php
+++ b/src/ConditionManager.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Safemood\Discountify\Contracts\ConditionManagerInterface;
+use Safemood\Discountify\Exceptions\DuplicateSlugException;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -30,6 +31,9 @@ class ConditionManager implements ConditionManagerInterface
                         throw new InvalidArgumentException('Slug must be provided.');
                     }
 
+
+                    $this->checkDuplicateSlug($condition['slug']);
+
                     return isset($condition['skip']) && $condition['skip'];
                 })
                 ->map(fn ($condition) => Arr::only($condition, ['slug', 'condition', 'discount']))
@@ -49,7 +53,10 @@ class ConditionManager implements ConditionManagerInterface
         if (empty($slug)) {
             throw new InvalidArgumentException('Slug must be provided.');
         }
-        if (! $skip) {
+
+        $this->checkDuplicateSlug($slug);
+
+        if (!$skip) {
             $this->conditions[] = compact('slug', 'condition', 'discount');
         }
 
@@ -87,7 +94,7 @@ class ConditionManager implements ConditionManagerInterface
 
         $directory = $path ?? base_path('app/Conditions');
 
-        if (! is_dir($directory)) {
+        if (!is_dir($directory)) {
             return $this;
         }
 
@@ -97,11 +104,11 @@ class ConditionManager implements ConditionManagerInterface
             ->depth(0)
             ->in($directory))
             ->each(function ($file) use ($namespace) {
-                $class = $namespace.$file->getBasename('.php');
+                $class = $namespace . $file->getBasename('.php');
                 $conditionInstance = new $class();
                 $skipping = property_exists($conditionInstance, 'skip') && $conditionInstance->skip;
 
-                if (method_exists($conditionInstance, '__invoke') && ! $skipping) {
+                if (method_exists($conditionInstance, '__invoke') && !$skipping) {
                     $slug = property_exists($conditionInstance, 'slug') ?
                         $conditionInstance->slug : strtolower(str_replace($namespace, '', $class));
 
@@ -115,5 +122,18 @@ class ConditionManager implements ConditionManagerInterface
             });
 
         return $this;
+    }
+
+    /**
+     * Check if a slug is already defined and throw an exception if it is.
+     *
+     * @param string $slug
+     * @throws \InvalidArgumentException
+     */
+    private function checkDuplicateSlug(string $slug): void
+    {
+        if (in_array($slug, array_column($this->conditions, 'slug'), true)) {
+            throw new DuplicateSlugException($slug);
+        }
     }
 }

--- a/src/ConditionManager.php
+++ b/src/ConditionManager.php
@@ -31,7 +31,6 @@ class ConditionManager implements ConditionManagerInterface
                         throw new InvalidArgumentException('Slug must be provided.');
                     }
 
-
                     $this->checkDuplicateSlug($condition['slug']);
 
                     return isset($condition['skip']) && $condition['skip'];
@@ -56,7 +55,7 @@ class ConditionManager implements ConditionManagerInterface
 
         $this->checkDuplicateSlug($slug);
 
-        if (!$skip) {
+        if (! $skip) {
             $this->conditions[] = compact('slug', 'condition', 'discount');
         }
 
@@ -94,7 +93,7 @@ class ConditionManager implements ConditionManagerInterface
 
         $directory = $path ?? base_path('app/Conditions');
 
-        if (!is_dir($directory)) {
+        if (! is_dir($directory)) {
             return $this;
         }
 
@@ -104,11 +103,11 @@ class ConditionManager implements ConditionManagerInterface
             ->depth(0)
             ->in($directory))
             ->each(function ($file) use ($namespace) {
-                $class = $namespace . $file->getBasename('.php');
+                $class = $namespace.$file->getBasename('.php');
                 $conditionInstance = new $class();
                 $skipping = property_exists($conditionInstance, 'skip') && $conditionInstance->skip;
 
-                if (method_exists($conditionInstance, '__invoke') && !$skipping) {
+                if (method_exists($conditionInstance, '__invoke') && ! $skipping) {
                     $slug = property_exists($conditionInstance, 'slug') ?
                         $conditionInstance->slug : strtolower(str_replace($namespace, '', $class));
 
@@ -127,7 +126,6 @@ class ConditionManager implements ConditionManagerInterface
     /**
      * Check if a slug is already defined and throw an exception if it is.
      *
-     * @param string $slug
      * @throws \InvalidArgumentException
      */
     private function checkDuplicateSlug(string $slug): void

--- a/src/Exceptions/DuplicateSlugException.php
+++ b/src/Exceptions/DuplicateSlugException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Safemood\Discountify\Exceptions;
+
+use InvalidArgumentException;
+
+class DuplicateSlugException extends InvalidArgumentException
+{
+    public function __construct(string $slug)
+    {
+        parent::__construct("Duplicate slug found: '{$slug}'. Each discount must have a unique identifier.");
+    }
+}

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -300,7 +300,6 @@ test('it skips class-based conditions marked with "skip"', function () {
 
 it('ensures condition slugs are unique', function () {
 
-
     Condition::define('unique_condition', fn () => true, 10);
 
     $this->expectException(DuplicateSlugException::class);

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Config;
 use Safemood\Discountify\ConditionManager;
 use Safemood\Discountify\Discountify;
+use Safemood\Discountify\Exceptions\DuplicateSlugException;
 use Safemood\Discountify\Facades\Condition;
 use Safemood\Discountify\Facades\Discountify as DiscountifyFacade;
 
@@ -295,4 +296,14 @@ test('it skips class-based conditions marked with "skip"', function () {
     $conditions = Condition::getConditions();
 
     expect($conditions)->toHaveCount(2);
+});
+
+it('ensures condition slugs are unique', function () {
+
+
+    Condition::define('unique_condition', fn () => true, 10);
+
+    $this->expectException(DuplicateSlugException::class);
+
+    Condition::define('unique_condition', fn () => true, 15);
 });


### PR DESCRIPTION
Modified the code to throw a `DuplicateSlugException` error when attempting to define a condition with a duplicate slug.
