### PR TITLE
Added Coupon Based Discounts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,84 @@ Check the [Laravel Events documentation](https://laravel.com/docs/10.x/events#re
 
 ### Coupon Based Discounts
 
-Coupon based discounts to easily apply and calculate discounts on a given coupon code (working on it !)
+Coupon based discounts to easily apply and calculate discounts (Percentage) on a given coupon code.
+
+Discountify Coupons allows you to apply various types of coupons to your cart.
+
+
+#### Time-Limited Coupon
+
+```php
+use Safemood\Discountify\Facades\Coupon;
+
+Coupon::add([
+    'code' => 'TIMELIMITED50',
+    'discount' => 50,
+    'singleUse' => true,
+    'startDate' => now(),
+    'endDate' => now()->addWeek(),
+]);
+
+$discountedTotal = Discountify::setItems($items)
+    ->applyCoupon('TIMELIMITED50')
+    ->total();
+```
+
+#### Single-Use Coupon
+
+```php
+use Safemood\Discountify\Facades\Coupon;
+
+Coupon::add([
+    'code' => 'SINGLEUSE50',
+    'discount' => 50,
+    'singleUse' => true,
+    'startDate' => now(),
+    'endDate' => now()->addWeek(),
+]);
+
+$discountedTotal = Discountify::setItems($items)
+    ->applyCoupon('SINGLEUSE50')
+    ->total();
+```
+
+#### Restricted User Coupon
+
+```php
+use Safemood\Discountify\Facades\Coupon;
+
+Coupon::add([
+    'code' => 'RESTRICTED20',
+    'discount' => 20,
+    'userIds' => [123, 456], // Restricted to user IDs 123 and 456
+    'startDate' => now(),
+    'endDate' => now()->addWeek(),
+]);
+
+$discountedTotal = Discountify::setItems($items)
+    ->applyCoupon('RESTRICTED20', 123) // Applying to user ID 123
+    ->total();
+```
+
+
+#### Limited Usage Coupon
+
+```php
+use Safemood\Discountify\Facades\Coupon;
+
+Coupon::add([
+    'code' => 'LIMITED25',
+    'discount' => 25,
+    'usageLimit' => 3, // Limited to 3 uses
+    'startDate' => now(),
+    'endDate' => now()->addWeek(),
+]);
+
+$discountedTotal = Discountify::setItems($items)
+    ->applyCoupon('LIMITED25')
+    ->total();
+
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ use Safemood\Discountify\Facades\Coupon;
 Coupon::add([
     'code' => 'TIMELIMITED50',
     'discount' => 50,
-    'singleUse' => true,
     'startDate' => now(),
     'endDate' => now()->addWeek(),
 ]);

--- a/src/Concerns/HasCalculations.php
+++ b/src/Concerns/HasCalculations.php
@@ -36,9 +36,33 @@ trait HasCalculations
         $this->globalDiscount = $globalDiscount ?? $this->globalDiscount;
 
         $total = $this->calculateTotal();
-        $discount = $this->calculateGlobalDiscount() + $this->evaluateConditions();
+        $globalDiscount = $this->calculateGlobalDiscount();
+        $couponDiscount = ($this->couponManager->couponDiscount() / 100) * $total;
+        $discount = $globalDiscount + $couponDiscount + $this->evaluateConditions();
 
         return max(0, $total - $discount);
+    }
+
+    /**
+     * Calculate total with the discount after tax.
+     */
+    public function calculateDiscountAfterTax(?int $globalDiscount = null): float
+    {
+
+        $total = $this->calculateTotal() + $this->calculateGlobalTax();
+        $globalDiscount = $this->calculateGlobalDiscount();
+        $couponDiscount = ($this->couponManager->couponDiscount() / 100) * $total;
+        $discount = $globalDiscount + $couponDiscount + $this->evaluateConditions();
+
+        return max(0, $total - $discount);
+    }
+
+    /**
+     * Calculate total with the discount before tax.
+     */
+    public function calculateDiscountBeforeTax(?int $globalDiscount = null): float
+    {
+        return $this->calculateDiscount($globalDiscount) + $this->calculateGlobalTax();
     }
 
     /**
@@ -90,8 +114,11 @@ trait HasCalculations
     /**
      * Get the total amount (after discounts and taxes).
      */
-    public function calculateFinalTotal(): float
+    public function calculateFinalTotal(bool $beforeTax = true): float
     {
-        return $this->calculateDiscount() + $this->calculateGlobalTax();
+
+        return $beforeTax ?
+            $this->calculateDiscountBeforeTax()
+            : $this->calculateDiscountAfterTax();
     }
 }

--- a/src/Concerns/HasConditions.php
+++ b/src/Concerns/HasConditions.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Safemood\Discountify\Concerns;
+
+use Safemood\Discountify\Discountify;
+
+/**
+ * Trait HasConditions
+ */
+trait HasConditions
+{
+    /**
+     * Define multiple conditions at once.
+     */
+    public function add(array $conditions): Discountify
+    {
+        $this->conditions()->add($conditions);
+
+        return $this;
+    }
+
+    /**
+     * Define a condition with a callback and a discount percentage.
+     */
+    public function define(string $slug, callable $condition, float $discount, bool $skip = false): Discountify
+    {
+        $this->conditions()->define($slug, $condition, $discount, $skip);
+
+        return $this;
+    }
+
+    /**
+     * Define a condition based on a boolean value and a discount percentage.
+     */
+    public function defineIf(string $slug, bool $isAcceptable, float $discount): Discountify
+    {
+        $this->conditions()->defineIf($slug, $isAcceptable, $discount);
+
+        return $this;
+    }
+
+    /**
+     * Get the applied conditions.
+     */
+    public function getConditions(): array
+    {
+        return $this->conditions()->getConditions();
+    }
+}

--- a/src/Concerns/HasCoupons.php
+++ b/src/Concerns/HasCoupons.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Safemood\Discountify\Concerns;
+
+/**
+ * Trait HasCoupons
+ */
+trait HasCoupons
+{
+    /**
+     * Add a coupon to the manager.
+     *
+     * @return $this
+     */
+    public function addCoupon(array $coupon): self
+    {
+        $this->coupons()->add($coupon);
+
+        return $this;
+    }
+
+    /**
+     * Remove a coupon from the manager.
+     *
+     * @return $this
+     */
+    public function removeCoupon(string $code): self
+    {
+        $this->coupons()->remove($code);
+
+        return $this;
+    }
+
+    /**
+     * Apply a coupon to an order.
+     */
+    public function applyCoupon(string $code, int|string|null $userId = null): self
+    {
+        $this->coupons()->apply($code, $userId);
+
+        return $this;
+    }
+
+    /**
+     * Get a coupon by code.
+     */
+    public function getCoupon(string $code): ?array
+    {
+        return $this->coupons()->get($code);
+    }
+
+    /**
+     * Get the total discount applied by coupons.
+     */
+    public function getCouponDiscount(): int
+    {
+        return $this->coupons()->couponDiscount();
+    }
+
+    /**
+     * Remove an applied coupon from the list of applied coupons.
+     */
+    public function removeAppliedCoupons(): self
+    {
+        $this->coupons()->removeAppliedCoupons();
+
+        return $this;
+    }
+
+    /**
+     * Clear all applied coupons.
+     */
+    public function clearAppliedCoupons(): self
+    {
+        $this->coupons()->clearAppliedCoupons();
+
+        return $this;
+    }
+
+    /**
+     * Get an array of applied coupons.
+     */
+    public function getAppliedCoupons(): array
+    {
+        return $this->coupons()->appliedCoupons();
+    }
+
+    /**
+     * Clear all coupons.
+     */
+    public function clear(): self
+    {
+        $this->coupons()->clear();
+
+        return $this;
+    }
+}

--- a/src/Contracts/DiscountifyInterface.php
+++ b/src/Contracts/DiscountifyInterface.php
@@ -3,13 +3,17 @@
 namespace Safemood\Discountify\Contracts;
 
 use Safemood\Discountify\ConditionManager;
-use Safemood\Discountify\Discountify;
+use Safemood\Discountify\CouponManager;
 
 interface DiscountifyInterface
 {
-    public function getConditionManager(): ConditionManager;
+    public function discount(int $globalDiscount): self;
 
-    public function getConditions(): array;
+    public function evaluateConditions(): float;
+
+    public function conditions(): ConditionManager;
+
+    public function coupons(): CouponManager;
 
     public function getGlobalDiscount(): int;
 
@@ -17,11 +21,23 @@ interface DiscountifyInterface
 
     public function getItems(): array;
 
-    public function setConditionManager(ConditionManager $conditionManager): Discountify;
+    public function setConditionManager(ConditionManager $conditionManager): self;
 
-    public function setGlobalDiscount(int $globalDiscount): Discountify;
+    public function setCouponManager(CouponManager $couponManager): self;
 
-    public function setGlobalTaxRate(float $globalTaxRate): Discountify;
+    public function setGlobalDiscount(int $globalDiscount): self;
 
-    public function setItems(array $items): Discountify;
+    public function setGlobalTaxRate(float $globalTaxRate): self;
+
+    public function setItems(array $items): self;
+
+    public function subtotal(): float;
+
+    public function tax(?float $globalTaxRate = null): float;
+
+    public function taxAmount(?float $globalTaxRate = null): float;
+
+    public function total(): float;
+
+    public function totalWithDiscount(?int $globalDiscount = null): float;
 }

--- a/src/CouponManager.php
+++ b/src/CouponManager.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Safemood\Discountify;
+
+/**
+ * Class CouponManager
+ */
+class CouponManager
+{
+    protected array $coupons = [];
+
+    /**
+     * Add a coupon to the manager.
+     *
+     * @return $this
+     */
+    public function add(array $coupon): self
+    {
+        $this->coupons[$coupon['code']] = $coupon;
+
+        return $this;
+    }
+
+    /**
+     * Remove a coupon from the manager.
+     *
+     * @return $this
+     */
+    public function remove(string $code): self
+    {
+        unset($this->coupons[$code]);
+
+        return $this;
+    }
+
+    /**
+     * Update a coupon in the manager.
+     *
+     * @return $this
+     */
+    public function update(string $code, array $updatedCoupon): self
+    {
+        $this->coupons[$code] = $updatedCoupon;
+
+        return $this;
+    }
+
+    /**
+     * Get all the coupons.
+     */
+    public function getCoupons(): array
+    {
+        return $this->coupons;
+    }
+
+    /**
+     * Get the total discount applied by coupons.
+     */
+    public function couponDiscount(): int
+    {
+        return collect($this->appliedCoupons())
+            ->sum(fn ($coupon) => $coupon['discount']);
+    }
+
+    /**
+     * Get a coupon by code.
+     */
+    public function get(string $code): ?array
+    {
+        return $this->coupons[$code] ?? null;
+    }
+
+    /**
+     * Apply a coupon to an order.
+     */
+    public function apply(string $code, int|string|null $userId = null): bool
+    {
+        if (! $this->verify($code, $userId)) {
+            return false;
+        }
+
+        $coupon = $this->get($code);
+
+        $coupon['applied'] = true;
+
+        $this->update($code, $coupon);
+
+        if ($userId) {
+            $this->trackUserForCoupon($coupon, $userId);
+        }
+
+        $this->decrementUsageLimit($coupon);
+
+        return true;
+    }
+
+    /**
+     * Check if a coupon is expired.
+     */
+    public function isCouponExpired(string $code): bool
+    {
+        return isset($this->coupons[$code]['endDate']) && strtotime($this->coupons[$code]['endDate']) < strtotime('now');
+    }
+
+    /**
+     * Get the list of all coupons.
+     */
+    public function all(): array
+    {
+        return $this->coupons;
+    }
+
+    /**
+     * Verify if a coupon is valid for use.
+     */
+    public function verify(string $code, int|string|null $userId = null): bool
+    {
+        $coupon = $this->get($code);
+
+        if ($coupon === null) {
+            return false;
+        }
+
+        if ($this->isCouponExpired($code)) {
+            return false;
+        }
+
+        if ($this->isCouponLimitedToUsers($coupon) && $userId === null) {
+            return false;
+        }
+
+        if (
+            $this->isCouponLimitedToUsers($coupon)
+            && ! $this->isUserAllowedToUseCoupon($coupon, $userId)
+        ) {
+            return false;
+        }
+
+        if (
+            $this->isCouponSingleUse($coupon)
+            && isset($coupon['applied'])
+            && $coupon['applied']
+        ) {
+            return false;
+        }
+
+        if (! $this->checkUsageLimit($coupon)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove an applied coupon from the list of applied coupons.
+     */
+    public function removeAppliedCoupons(): self
+    {
+        $this->coupons = collect($this->coupons)
+            ->reject(function ($coupon) {
+                return $coupon['applied'] ?? false;
+            })->toArray();
+
+        return $this;
+    }
+
+    /**
+     * Clear all applied coupons.
+     */
+    public function clearAppliedCoupons(): self
+    {
+        $this->coupons = collect($this->coupons)->reject(function ($coupon) {
+            return $coupon['applied'] ?? false;
+        })->toArray();
+
+        return $this;
+    }
+
+    /**
+     * Get an array of applied coupons.
+     */
+    public function appliedCoupons(): array
+    {
+        return collect($this->coupons)->filter(function ($coupon) {
+            return $coupon['applied'] ?? false;
+        })->values()->all();
+    }
+
+    /**
+     * Clear all coupons.
+     */
+    public function clear(): self
+    {
+        $this->coupons = [];
+
+        return $this;
+    }
+
+    /**
+     * Decrement the usage limit of a coupon if applicable.
+     */
+    protected function decrementUsageLimit(array $coupon): void
+    {
+        if (isset($coupon['usageLimit']) && $coupon['usageLimit'] > 0) {
+
+            $coupon['usageLimit']--;
+
+            $this->update($coupon['code'], $coupon);
+        }
+    }
+
+    /**
+     * Check if the coupon usage limit has been reached.
+     */
+    protected function checkUsageLimit(array $coupon): bool
+    {
+        return ! isset($coupon['usageLimit']) || $coupon['usageLimit'] > 0;
+    }
+
+    /**
+     * Track the user who used the coupon.
+     */
+    protected function trackUserForCoupon(array $coupon, int $userId): void
+    {
+        $coupon['usedBy'][] = $userId;
+        $this->update($coupon['code'], $coupon);
+    }
+
+    protected function isCouponSingleUse(array $coupon): bool
+    {
+        return isset($coupon['singleUse']) && $coupon['singleUse'] === true;
+    }
+
+    protected function isCouponAlreadyUsedByUser(array $coupon, int|string $userId): bool
+    {
+        return isset($coupon['usedBy']) && in_array($userId, $coupon['usedBy'], true);
+    }
+
+    protected function isCouponLimitedToUsers(array $coupon): bool
+    {
+        return isset($coupon['userIds']);
+    }
+
+    protected function isUserAllowedToUseCoupon(array $coupon, int|string $userId): bool
+    {
+        return isset($coupon['userIds']) && in_array($userId, $coupon['userIds'], true);
+    }
+}

--- a/src/DiscountifyServiceProvider.php
+++ b/src/DiscountifyServiceProvider.php
@@ -20,7 +20,7 @@ class DiscountifyServiceProvider extends PackageServiceProvider
     public function packageRegistered()
     {
 
-        $this->app->singleton(ConditionManager::class, function ($app) {
+        $this->app->singleton(ConditionManager::class, function () {
             $conditionManager = new ConditionManager();
 
             $conditionManager->discover(
@@ -31,8 +31,15 @@ class DiscountifyServiceProvider extends PackageServiceProvider
             return $conditionManager;
         });
 
+        $this->app->singleton(CouponManager::class, function () {
+            return new CouponManager();
+        });
+
         $this->app->singleton(Discountify::class, function (Application $app) {
-            return new Discountify($app->make(ConditionManager::class));
+            return new Discountify(
+                $app->make(ConditionManager::class),
+                $app->make(CouponManager::class)
+            );
         });
     }
 }

--- a/src/Facades/Coupon.php
+++ b/src/Facades/Coupon.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Safemood\Discountify\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Class Coupon
+ *
+ * @method static \Safemood\Discountify\CouponManager add(array $coupon) Add a coupon to the manager.
+ * @method static \Safemood\Discountify\CouponManager remove(string $code) Remove a coupon from the manager.
+ * @method static \Safemood\Discountify\CouponManager update(string $code, array $updatedCoupon) Update a coupon in the manager.
+ * @method static array all() Get the list of all coupons.
+ * @method static int couponDiscount() Get the total discount applied by coupons.
+ * @method static array|null get(string $code) Get a coupon by code.
+ * @method static void apply(string $code, int|string $userId = null) Apply a coupon to an order.
+ * @method static bool isCouponExpired(string $code) Check if a coupon is expired.
+ * @method static bool verify(string $code, int|string $userId = null) Verify if a coupon is valid for use.
+ * @method static \Safemood\Discountify\CouponManager removeAppliedCoupons() Remove applied coupons.
+ * @method static \Safemood\Discountify\CouponManager clearAppliedCoupons() Clear all applied coupons.
+ * @method static array appliedCoupons() Get an array of applied coupons.
+ *
+ * @see \Safemood\Discountify\CouponManager
+ */
+class Coupon extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return \Safemood\Discountify\CouponManager::class;
+    }
+}

--- a/src/Facades/Discountify.php
+++ b/src/Facades/Discountify.php
@@ -10,9 +10,10 @@ use Safemood\Discountify\ConditionManager;
  *
  * @method static \Safemood\Discountify\Discountify discount(float $globalDiscount)
  * @method static array getConditions()
- * @method static ConditionManager getConditionManager()
+ * @method static ConditionManager conditions()
+ * @method static CouponManager coupons()
  * @method static int getGlobalDiscount()
- * @method static float getGlobalTaxRate()
+ * @method static int getGlobalTaxRate()
  * @method static array getItems()
  * @method static float subtotal()
  * @method static float total()

--- a/tests/CouponMangerTest.php
+++ b/tests/CouponMangerTest.php
@@ -1,0 +1,324 @@
+<?php
+
+use Safemood\Discountify\CouponManager;
+use Safemood\Discountify\Facades\Coupon;
+
+beforeEach(function () {
+
+    $this->couponManager = new CouponManager();
+});
+
+it('adds, retrieves, updates, and removes coupons', function () {
+
+    $coupon = [
+        'code' => 'WELCOME20',
+        'discount' => 20,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    $this->couponManager->add($coupon);
+
+    expect($this->couponManager->get('WELCOME20'))->toBe($coupon);
+
+    $updatedCoupon = [
+        'code' => 'WELCOME20',
+        'discount' => 25,
+        'startDate' => now(),
+        'endDate' => now()->addWeeks(2),
+    ];
+
+    $this->couponManager->update('WELCOME20', $updatedCoupon);
+    expect($this->couponManager->get('WELCOME20'))->toBe($updatedCoupon);
+
+    $this->couponManager->remove('WELCOME20');
+    expect($this->couponManager->get('WELCOME20'))->toBeNull();
+});
+
+it('checks if coupon is expired', function () {
+
+    $futureCoupon = [
+        'code' => 'FUTURE10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $this->couponManager->add($futureCoupon);
+    expect($this->couponManager->isCouponExpired('FUTURE10'))->toBeFalse();
+
+    $pastCoupon = [
+        'code' => 'PAST15',
+        'discount' => 15,
+        'startDate' => now(),
+        'endDate' => now()->subWeek(),
+    ];
+    $this->couponManager->add($pastCoupon);
+    expect($this->couponManager->isCouponExpired('PAST15'))->toBeTrue();
+});
+
+it('verifies coupon validity for a user', function () {
+
+    $coupon = [
+        'code' => 'WELCOME20',
+        'discount' => 20,
+        'userIds' => [123],
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $this->couponManager->add($coupon);
+
+    expect($this->couponManager->verify('WELCOME20', 123))->toBeTrue();
+
+    expect($this->couponManager->verify('WELCOME20', 456))->toBeFalse();
+
+    $expiredCoupon = [
+        'code' => 'EXPIRED10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->subWeek(),
+    ];
+    $this->couponManager->add($expiredCoupon);
+    expect($this->couponManager->verify('EXPIRED10'))->toBeFalse();
+});
+
+it('applies a single-use coupon only once', function () {
+
+    $coupon = [
+        'code' => 'SINGLEUSE10',
+        'discount' => 10,
+        'singleUse' => true,
+        'startDate' => '2024-02-01',
+        'endDate' => '2024-02-28',
+    ];
+
+    $this->couponManager->add($coupon);
+
+    expect($this->couponManager->apply('SINGLEUSE10'))->toBeTrue();
+    expect($this->couponManager->apply('SINGLEUSE10'))->toBeFalse();
+});
+
+it('tracks users who used the coupon', function () {
+
+    $coupon = [
+        'code' => 'TRACKED20',
+        'discount' => 20,
+        'startDate' => '2024-02-01',
+        'endDate' => '2024-02-28',
+    ];
+    $this->couponManager->add($coupon);
+
+    $this->couponManager->apply('TRACKED20', 123);
+
+    $this->couponManager->apply('TRACKED20', 456);
+
+    expect($this->couponManager->get('TRACKED20')['usedBy'])->toContain(123);
+    expect($this->couponManager->get('TRACKED20')['usedBy'])->toContain(456);
+});
+
+it('returns zero discount when no coupons are applied', function () {
+
+    expect($this->couponManager->couponDiscount())->toBe(0);
+});
+
+it('handles coupon usage limit', function () {
+    $coupon = [
+        'code' => 'LIMITED25',
+        'discount' => 25,
+        'usageLimit' => 2,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $this->couponManager->add($coupon);
+
+    expect($this->couponManager->apply('LIMITED25'))->toBeTrue();
+
+    expect($this->couponManager->apply('LIMITED25'))->toBeTrue();
+
+    expect($this->couponManager->apply('LIMITED25'))->toBeFalse();
+});
+
+it('removes an applied coupon', function () {
+
+    $coupon = [
+        'code' => 'DISCOUNT10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $this->couponManager->add($coupon);
+
+    $this->couponManager->apply('DISCOUNT10');
+
+    expect($this->couponManager->get('DISCOUNT10'))->not->toBeNull();
+
+    $this->couponManager->removeAppliedCoupons();
+
+    expect($this->couponManager->get('DISCOUNT10'))->toBeNull();
+});
+
+it('clears all applied coupons', function () {
+
+    $coupons = [
+        [
+            'code' => 'DISCOUNT10', 'discount' => 10,
+            'startDate' => now(), 'endDate' => now()->addWeek(),
+        ],
+        [
+            'code' => 'SALE20', 'discount' => 20,
+            'startDate' => now(), 'endDate' => now()->addWeek(),
+        ],
+    ];
+
+    foreach ($coupons as $coupon) {
+        $this->couponManager->add($coupon);
+        $this->couponManager->apply($coupon['code']);
+    }
+
+    expect(count($this->couponManager->appliedCoupons()))->toBe(2);
+
+    $this->couponManager->clearAppliedCoupons();
+
+    expect($this->couponManager->appliedCoupons())->toBeEmpty();
+});
+
+it('applies coupon with usage limit', function () {
+
+    $coupon = [
+        'code' => 'UNLIMITED10',
+        'discount' => 10,
+        'usageLimit' => 2,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    $this->couponManager->add($coupon);
+
+    $this->couponManager->apply('UNLIMITED10');
+    $this->couponManager->apply('UNLIMITED10');
+
+    $appliedCoupon = $this->couponManager->get('UNLIMITED10');
+
+    expect($appliedCoupon['usageLimit'])->toBe(0);
+
+    expect($this->couponManager->apply('UNLIMITED10'))->toBeFalse();
+});
+
+it('applies coupon only to restricted users', function () {
+    $coupon = [
+        'code' => 'USER20',
+        'discount' => 20,
+        'userIds' => [1, 2], // Restricted to users with IDs 1 and 2
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $this->couponManager->add($coupon);
+
+    expect($this->couponManager->apply('USER20'))->toBeFalse();
+    expect($this->couponManager->apply('USER20', 1))->toBeTrue();
+    expect($this->couponManager->apply('USER20', 2))->toBeTrue();
+    expect($this->couponManager->apply('USER20', 3))->toBeFalse();
+});
+
+it('removes a coupon via the facade', function () {
+    $coupon = [
+        'code' => 'WELCOME20',
+        'discount' => 20,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    Coupon::add($coupon);
+    Coupon::remove('WELCOME20');
+    expect(Coupon::get('WELCOME20'))->toBeNull();
+});
+
+it('checks if a coupon is expired via the facade', function () {
+    $coupon = [
+        'code' => 'EXPIRED10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->subWeek(),
+    ];
+
+    Coupon::add($coupon);
+    expect(Coupon::isCouponExpired('EXPIRED10'))->toBeTrue();
+});
+
+it('clears all applied coupons via the facade', function () {
+    $coupon1 = [
+        'code' => 'SALE10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $coupon2 = [
+        'code' => 'SALE20',
+        'discount' => 20,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    Coupon::add($coupon1);
+    Coupon::add($coupon2);
+
+    Coupon::apply('SALE10');
+    Coupon::apply('SALE20');
+
+    Coupon::clearAppliedCoupons();
+
+    expect(Coupon::appliedCoupons())->toBeEmpty();
+});
+
+it('returns the total discount applied by coupons via the facade', function () {
+    $coupon1 = [
+        'code' => 'DISCOUNT10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+    $coupon2 = [
+        'code' => 'DISCOUNT20',
+        'discount' => 20,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    Coupon::add($coupon1);
+    Coupon::add($coupon2);
+
+    Coupon::apply('DISCOUNT10');
+    Coupon::apply('DISCOUNT20');
+
+    expect(Coupon::couponDiscount())->toBe(30);
+});
+
+it('verifies if a coupon is valid for use via the facade', function () {
+    $coupon = [
+        'code' => 'WELCOME20',
+        'discount' => 20,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    $userId = 123;
+
+    Coupon::add($coupon);
+    expect(Coupon::verify('WELCOME20', $userId))->toBe(true);
+});
+
+it('removes an applied coupon from the list of applied coupons via the facade', function () {
+    $coupon = [
+        'code' => 'DISCOUNT10',
+        'discount' => 10,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ];
+
+    Coupon::add($coupon);
+
+    Coupon::apply('DISCOUNT10');
+    expect(Coupon::get('DISCOUNT10')['applied'])->toBe(true);
+
+    Coupon::removeAppliedCoupons();
+    expect(Coupon::get('DISCOUNT10'))->toBeNull();
+});


### PR DESCRIPTION
This PR implements coupon-based discounts, allowing users to apply various types of coupons to their cart items. It includes tests covering scenarios such as applying time-limited coupons, single-use coupons, restricted user coupons, and limited usage coupons. Additionally, the README file has been updated with code examples demonstrating how to utilize different types of coupons.

#### Coupon Examples

```php
use Safemood\Discountify\Facades\Coupon;


// Time-Limited Coupon

Coupon::add([
    'code' => 'TIMELIMITED50',
    'discount' => 50,
    'startDate' => now(),
    'endDate' => now()->addWeek(),
]);

$total = Discountify::setItems($items)
    ->applyCoupon('TIMELIMITED50')
    ->total();

// Single-Use Coupon

Coupon::add([
    'code' => 'SINGLEUSE50',
    'discount' => 50,
    'singleUse' => true,
    'startDate' => now(),
    'endDate' => now()->addWeek(),
]);

$total = Discountify::setItems($items)
    ->applyCoupon('SINGLEUSE50')
    ->total();

// Restricted User Coupon

Coupon::add([
    'code' => 'RESTRICTED20',
    'discount' => 20,
    'userIds' => [123, 456], // Restricted to user IDs 123 and 456
    'startDate' => now(),
    'endDate' => now()->addWeek(),
]);

$total = Discountify::setItems($items)
    ->applyCoupon('RESTRICTED20', 123) // Applying to user ID 123
    ->total();

// Limited Usage Coupon

Coupon::add([
    'code' => 'LIMITED25',
    'discount' => 25,
    'usageLimit' => 3, // Limited to 3 uses
    'startDate' => now(),
    'endDate' => now()->addWeek(),
]);

$total = Discountify::setItems($items)
    ->applyCoupon('LIMITED25')
    ->total();
```