### PR TITLE
Update version constraint for illuminate/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1|^8.2",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0"
+        "illuminate/contracts": "^10|^11.1"
     },
     "require-dev": {
         "laravel/pint": "^1.13.7",


### PR DESCRIPTION
This PR updates the version constraint for `illuminate/contracts` to ensure compatibility with Laravel 10.x and 11.x. Previously, the constraint was set to "^10.0|^11.0", which allowed for Laravel 10.x and 11.0. With this update, the constraint is adjusted to "^10|^11.1", which includes Laravel 11.1 and above. This change ensures that users can utilize the latest features and fixes provided by Laravel.