### PR TITLE
18 bug reduce the number and not percent

### DIFF
--- a/src/Discountify.php
+++ b/src/Discountify.php
@@ -84,7 +84,7 @@ class Discountify implements DiscountifyInterface
 
                 return $discount + match (true) {
                     $result === true => $this->calculateSubtotal() * ($condition['discount'] / 100),
-                    default => $condition['discount'],
+                    default => 0,
                 };
             },
             0


### PR DESCRIPTION
Previously, there was a bug in the discount calculation logic in the `evaluateConditions()` method. The default discount was incorrectly set to `$condition['discount']`, leading to unexpected behavior when no specific discount was provided. This commit fixes the bug by setting the default discount to 0, ensuring that no discount is applied by default unless explicitly specified.

Fixes: #18 #19 

```php
it('calculates total with discount applied during the early spring sale period', function () {
    Carbon::setTestNow(Carbon::create(2024, 3, 10)); // date within the early spring sale period

    $isInTheDate = now()->between(
        Carbon::createFromDate(2024, 3, 1),
        Carbon::createFromDate(2024, 3, 22)->addDays(7)
    );

    Condition::add([
        [
            'slug' => 'promo_early_spring_sale_2024',
            'condition' => fn ($items) => $isInTheDate,
            'discount' => 15,
        ],
    ]);

    $cart = [
        [
            'id' => 1,
            'product_id' => 1,
            'product_name' => 'Product 1',
            'quantity' => 5,
            'price' => 10,
        ],
        [
            'id' => 2,
            'product_id' => 2,
            'product_name' => 'Product 2',
            'quantity' => 2,
            'price' => 20,
        ],
    ];

    $total = DiscountifyFacade::setItems($cart)->total();
    expect($isInTheDate)->toBeTrue();
    expect($total)->toBe(floatval(76.5)); // Total after applying a 15% discount
});

it('calculates total without discount applied outside the early spring sale period', function () {
    Carbon::setTestNow(Carbon::create(2024, 2, 15)); // date outside the early spring sale period

    $isInTheDate = now()->between(
        Carbon::createFromDate(2024, 3, 1),
        Carbon::createFromDate(2024, 3, 22)->addDays(7)
    );

    Condition::add([
        [
            'slug' => 'promo_early_spring_sale_2024',
            'condition' => fn ($items) => $isInTheDate,
            'discount' => 15,
        ],
    ]);

    $cart = [
        [
            'id' => 1,
            'product_id' => 1,
            'product_name' => 'Product 1',
            'quantity' => 5,
            'price' => 10,
        ],
        [
            'id' => 2,
            'product_id' => 2,
            'product_name' => 'Product 2',
            'quantity' => 2,
            'price' => 20,
        ],
    ];

    $total = DiscountifyFacade::setItems($cart)->total();

    expect($isInTheDate)->toBeFalse();
    expect($total)->toBe(floatval(90)); // Total without any discount applied
});
```