### PR TITLE
Bug Fix: Ensure Limited Usage Coupon is Applied Only Once

### DIFF
--- a/src/CouponManager.php
+++ b/src/CouponManager.php
@@ -75,7 +75,7 @@ class CouponManager
      */
     public function apply(string $code, int|string|null $userId = null): bool
     {
-        if (!$this->verify($code, $userId)) {
+        if (! $this->verify($code, $userId)) {
             return false;
         }
 
@@ -131,7 +131,7 @@ class CouponManager
 
         if (
             $this->isCouponLimitedToUsers($coupon)
-            && !$this->isUserAllowedToUseCoupon($coupon, $userId)
+            && ! $this->isUserAllowedToUseCoupon($coupon, $userId)
         ) {
             return false;
         }
@@ -144,8 +144,9 @@ class CouponManager
             return false;
         }
 
-        if (!$this->checkUsageLimit($coupon)) {
+        if (! $this->checkUsageLimit($coupon)) {
             $this->remove($code);
+
             return false;
         }
 
@@ -215,7 +216,7 @@ class CouponManager
      */
     protected function checkUsageLimit(array $coupon): bool
     {
-        return !isset($coupon['usageLimit']) || $coupon['usageLimit'] > 0;
+        return ! isset($coupon['usageLimit']) || $coupon['usageLimit'] > 0;
     }
 
     /**

--- a/src/CouponManager.php
+++ b/src/CouponManager.php
@@ -75,7 +75,7 @@ class CouponManager
      */
     public function apply(string $code, int|string|null $userId = null): bool
     {
-        if (! $this->verify($code, $userId)) {
+        if (!$this->verify($code, $userId)) {
             return false;
         }
 
@@ -131,7 +131,7 @@ class CouponManager
 
         if (
             $this->isCouponLimitedToUsers($coupon)
-            && ! $this->isUserAllowedToUseCoupon($coupon, $userId)
+            && !$this->isUserAllowedToUseCoupon($coupon, $userId)
         ) {
             return false;
         }
@@ -144,7 +144,8 @@ class CouponManager
             return false;
         }
 
-        if (! $this->checkUsageLimit($coupon)) {
+        if (!$this->checkUsageLimit($coupon)) {
+            $this->remove($code);
             return false;
         }
 
@@ -214,7 +215,7 @@ class CouponManager
      */
     protected function checkUsageLimit(array $coupon): bool
     {
-        return ! isset($coupon['usageLimit']) || $coupon['usageLimit'] > 0;
+        return !isset($coupon['usageLimit']) || $coupon['usageLimit'] > 0;
     }
 
     /**

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -537,7 +537,6 @@ it('calculates total without discount applied outside the early spring sale peri
 
 it('applies limited usage coupon only once', function () {
 
-
     Coupon::add([
         'code' => 'LIMITED50',
         'discount' => 50,
@@ -546,37 +545,34 @@ it('applies limited usage coupon only once', function () {
         'endDate' => now()->addWeek(),
     ]);
 
- 
     $items = [
         [
-            "id" => 1,
-            "product_id" => 1,
-            "product_name" => "Product 1",
-            "quantity" => 5,
-            "price" => 10
+            'id' => 1,
+            'product_id' => 1,
+            'product_name' => 'Product 1',
+            'quantity' => 5,
+            'price' => 10,
         ],
         [
-            "id" => 2,
-            "product_id" => 2,
-            "product_name" => "Product 2",
-            "quantity" => 2,
-            "price" => 25
-        ]
+            'id' => 2,
+            'product_id' => 2,
+            'product_name' => 'Product 2',
+            'quantity' => 2,
+            'price' => 25,
+        ],
     ];
 
     $discountedTotal1 = DiscountifyFacade::setItems($items)
         ->applyCoupon('LIMITED50')
         ->total();
 
-    $appleied1 =  DiscountifyFacade::coupons()->appliedCoupons();
-
+    $appleied1 = DiscountifyFacade::coupons()->appliedCoupons();
 
     $discountedTotal2 = DiscountifyFacade::setItems($items)
         ->applyCoupon('LIMITED50')
         ->total();
 
-    $appleied2 =  DiscountifyFacade::coupons()->appliedCoupons();
-
+    $appleied2 = DiscountifyFacade::coupons()->appliedCoupons();
 
     expect($discountedTotal1)->toBe(floatval(50));
     expect($appleied1)->not->toBeEmpty();

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -534,3 +534,55 @@ it('calculates total without discount applied outside the early spring sale peri
     expect($isInTheDate)->toBeFalse();
     expect($total)->toBe(floatval(90)); // Total without any discount applied
 });
+
+it('applies limited usage coupon only once', function () {
+
+
+    Coupon::add([
+        'code' => 'LIMITED50',
+        'discount' => 50,
+        'usageLimit' => 1, // Limited to 1 uses
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ]);
+
+ 
+    $items = [
+        [
+            "id" => 1,
+            "product_id" => 1,
+            "product_name" => "Product 1",
+            "quantity" => 5,
+            "price" => 10
+        ],
+        [
+            "id" => 2,
+            "product_id" => 2,
+            "product_name" => "Product 2",
+            "quantity" => 2,
+            "price" => 25
+        ]
+    ];
+
+    $discountedTotal1 = DiscountifyFacade::setItems($items)
+        ->applyCoupon('LIMITED50')
+        ->total();
+
+    $appleied1 =  DiscountifyFacade::coupons()->appliedCoupons();
+
+
+    $discountedTotal2 = DiscountifyFacade::setItems($items)
+        ->applyCoupon('LIMITED50')
+        ->total();
+
+    $appleied2 =  DiscountifyFacade::coupons()->appliedCoupons();
+
+
+    expect($discountedTotal1)->toBe(floatval(50));
+    expect($appleied1)->not->toBeEmpty();
+    expect($appleied1[0]['code'])->toEqual('LIMITED50');
+
+    expect($discountedTotal2)->toBe(floatval(100)); // without the discount
+    expect($appleied2)->toBeEmpty();
+
+});


### PR DESCRIPTION
This PR addresses the issue of Limited Usage Coupons being mistakenly applied multiple times. The fix involves removing the coupon from the list when it reaches its usage limit, preventing further unintended applications. 

Additionally, test cases have been added to validate this behavior. These tests confirm that when a Limited Usage Coupon reaches its usage limit, it is properly removed from the list, ensuring reliable prevention of the bug's recurrence.


```php

it('applies limited usage coupon only once', function () {


    Coupon::add([
        'code' => 'LIMITED50',
        'discount' => 50,
        'usageLimit' => 1, // Limited to 1 uses
        'startDate' => now(),
        'endDate' => now()->addWeek(),
    ]);

 
    $items = [
        [
            "id" => 1,
            "product_id" => 1,
            "product_name" => "Product 1",
            "quantity" => 5,
            "price" => 10
        ],
        [
            "id" => 2,
            "product_id" => 2,
            "product_name" => "Product 2",
            "quantity" => 2,
            "price" => 25
        ]
    ];

    $discountedTotal1 = DiscountifyFacade::setItems($items)
        ->applyCoupon('LIMITED50')
        ->total();

    $appleied1 =  DiscountifyFacade::coupons()->appliedCoupons();


    $discountedTotal2 = DiscountifyFacade::setItems($items)
        ->applyCoupon('LIMITED50')
        ->total();

    $appleied2 =  DiscountifyFacade::coupons()->appliedCoupons();


    expect($discountedTotal1)->toBe(floatval(50));
    expect($appleied1)->not->toBeEmpty();
    expect($appleied1[0]['code'])->toEqual('LIMITED50');

    expect($discountedTotal2)->toBe(floatval(100)); // without the discount
    expect($appleied2)->toBeEmpty();

});
```