### PR TITLE
31 bug state management issues for single-use and usage-limited coupons

### DIFF
--- a/config/discountify.php
+++ b/config/discountify.php
@@ -12,4 +12,5 @@ return [
     'global_discount' => 0,
     'global_tax_rate' => 0,
     'fire_events' => env('DISCOUNTIFY_FIRE_EVENTS', true),
+    'state_file_path' => env('DISCOUNTIFY_STATE_FILE_PATH', storage_path('app/discountify/coupons.json')),
 ];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,5 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-
+    ignoreErrors:
+        - identifier: missingType.iterableValue

--- a/src/Concerns/HasCalculations.php
+++ b/src/Concerns/HasCalculations.php
@@ -89,7 +89,7 @@ trait HasCalculations
                 $price = $this->getField($item, 'price');
 
                 if ($quantity === 0) {
-                    throw new ZeroQuantityException();
+                    throw new ZeroQuantityException;
                 }
 
                 return $total + ($quantity * $price);

--- a/src/Concerns/HasStateTracking.php
+++ b/src/Concerns/HasStateTracking.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Safemood\Discountify\Concerns;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+
+trait HasStateTracking
+{
+    protected string $stateFilePath;
+
+    public function setStateFilePath(string $path): self
+    {
+        $this->stateFilePath = $path;
+        $this->ensureStateFileExists();
+        $this->loadState();
+
+        return $this;
+    }
+
+    protected function ensureStateFileExists(): void
+    {
+
+        $directory = dirname($this->stateFilePath);
+        if (! File::exists($directory)) {
+            File::makeDirectory($directory, 0755, true);
+        }
+
+        if (! File::exists($this->stateFilePath)) {
+            File::put($this->stateFilePath, json_encode([]));
+        }
+    }
+
+    /**
+     * Load the state from the file, converting date strings back to Carbon instances.
+     */
+    protected function loadState(): void
+    {
+        if (File::exists($this->stateFilePath)) {
+            $this->coupons = json_decode(File::get($this->stateFilePath), true) ?: [];
+
+            // Convert ISO date strings to Carbon instances during load
+            foreach ($this->coupons as &$coupon) {
+                $coupon = $this->convertDatesToCarbon($coupon);
+            }
+        }
+    }
+
+    /**
+     * Save the state to the file, converting Carbon dates to ISO strings.
+     */
+    protected function saveState(): void
+    {
+        // Convert Carbon date instances to ISO strings before saving
+        $couponsToSave = array_map([$this, 'convertDatesToIso'], $this->coupons);
+
+        File::put($this->stateFilePath, json_encode($couponsToSave));
+    }
+
+    /**
+     * Convert ISO date strings to Carbon instances for the given coupon.
+     *
+     * @param  array  $coupon  The coupon to convert.
+     * @return array The coupon with Carbon instances for dates.
+     */
+    protected function convertDatesToCarbon(array $coupon): array
+    {
+        if (isset($coupon['startDate']) && is_string($coupon['startDate'])) {
+            $coupon['startDate'] = Carbon::parse($coupon['startDate']);
+        }
+
+        if (isset($coupon['endDate']) && is_string($coupon['endDate'])) {
+            $coupon['endDate'] = Carbon::parse($coupon['endDate']);
+        }
+
+        return $coupon;
+    }
+
+    /**
+     * Convert Carbon instances to ISO strings for the given coupon.
+     *
+     * @param  array  $coupon  The coupon to convert.
+     * @return array The coupon with ISO date strings.
+     */
+    protected function convertDatesToIso(array $coupon): array
+    {
+        if (isset($coupon['startDate']) && $coupon['startDate'] instanceof \Carbon\Carbon) {
+            $coupon['startDate'] = $coupon['startDate']->toISOString();
+        }
+
+        if (isset($coupon['endDate']) && $coupon['endDate'] instanceof \Carbon\Carbon) {
+            $coupon['endDate'] = $coupon['endDate']->toISOString();
+        }
+
+        return $coupon;
+    }
+}

--- a/src/Concerns/HasStateTracking.php
+++ b/src/Concerns/HasStateTracking.php
@@ -29,7 +29,7 @@ trait HasStateTracking
         }
 
         if (! File::exists($this->stateFilePath)) {
-            File::put($this->stateFilePath, json_encode([]));
+            File::put($this->stateFilePath, '{}');
         }
     }
 
@@ -56,7 +56,12 @@ trait HasStateTracking
         // Convert Carbon date instances to ISO strings before saving
         $couponsToSave = array_map([$this, 'convertDatesToIso'], $this->coupons);
 
-        File::put($this->stateFilePath, json_encode($couponsToSave));
+        $jsonContents = json_encode($couponsToSave);
+        if ($jsonContents === false) {
+            throw new \RuntimeException('Failed to encode state to JSON: '.json_last_error_msg());
+        }
+
+        File::put($this->stateFilePath, $jsonContents);
     }
 
     /**

--- a/src/ConditionManager.php
+++ b/src/ConditionManager.php
@@ -107,7 +107,7 @@ class ConditionManager implements ConditionManagerInterface
                 $class = $namespace.$file->getBasename('.php');
 
                 if (class_exists($class)) {
-                    $conditionInstance = new $class();
+                    $conditionInstance = new $class;
                     $skipping = property_exists($conditionInstance, 'skip') && $conditionInstance->skip;
 
                     if (method_exists($conditionInstance, '__invoke') && ! $skipping) {

--- a/src/DiscountifyServiceProvider.php
+++ b/src/DiscountifyServiceProvider.php
@@ -23,7 +23,7 @@ class DiscountifyServiceProvider extends PackageServiceProvider
     {
 
         $this->app->singleton(ConditionManager::class, function () {
-            $conditionManager = new ConditionManager();
+            $conditionManager = new ConditionManager;
 
             $conditionManager->discover(
                 config('discountify.condition_namespace'),
@@ -34,7 +34,7 @@ class DiscountifyServiceProvider extends PackageServiceProvider
         });
 
         $this->app->singleton(CouponManager::class, function () {
-            return new CouponManager();
+            return new CouponManager;
         });
 
         $this->app->singleton(Discountify::class, function (Application $app) {

--- a/src/Events/CouponAppliedEvent.php
+++ b/src/Events/CouponAppliedEvent.php
@@ -8,6 +8,5 @@ class CouponAppliedEvent
 {
     public function __construct(
         public array $coupon,
-    ) {
-    }
+    ) {}
 }

--- a/src/Events/DiscountAppliedEvent.php
+++ b/src/Events/DiscountAppliedEvent.php
@@ -10,6 +10,5 @@ class DiscountAppliedEvent
         public string $slug,
         public float $discount,
         public mixed $condition
-    ) {
-    }
+    ) {}
 }

--- a/tests/ConditionManagerTest.php
+++ b/tests/ConditionManagerTest.php
@@ -10,7 +10,7 @@ use function Orchestra\Testbench\workbench_path;
 
 beforeEach(function () {
 
-    $this->conditionManger = new ConditionManager();
+    $this->conditionManger = new ConditionManager;
 });
 
 it('can add conditions using ConditionManager', function () {

--- a/tests/CouponManagerTest.php
+++ b/tests/CouponManagerTest.php
@@ -11,7 +11,7 @@ use function Orchestra\Testbench\workbench_path;
 beforeEach(function () {
     $this->stateFilePath = workbench_path('app/test_state.json');
     config(['discountify.state_file_path' => $this->stateFilePath]);
-    $this->couponManager = new CouponManager();
+    $this->couponManager = new CouponManager;
 });
 
 afterEach(function () {
@@ -423,7 +423,7 @@ it('applies a single-use coupon and prevents reapplication', function () {
 
     Coupon::apply('SINGLEUSE50');
 
-    $this->couponManager = new CouponManager();
+    $this->couponManager = new CouponManager;
 
     $secondApplication = $this->couponManager->apply('SINGLEUSE50');
 
@@ -447,13 +447,13 @@ it('It applies a limited-use coupon and retains its state across instances',
 
         expect($firstApplication)->toBeTrue();
 
-        $this->couponManager = new CouponManager();
+        $this->couponManager = new CouponManager;
 
         $secondApplication = $this->couponManager->apply('LIMITED10');
 
         expect($secondApplication)->toBeTrue();
 
-        $this->couponManager = new CouponManager();
+        $this->couponManager = new CouponManager;
 
         $lastApplication = $this->couponManager->apply('LIMITED10');
 

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -26,8 +26,8 @@ beforeEach(function () {
     ];
     $this->stateFilePath = workbench_path('app/test_state.json');
     config(['discountify.state_file_path' => $this->stateFilePath]);
-    $this->conditionManager = new ConditionManager();
-    $this->couponManager = new CouponManager();
+    $this->conditionManager = new ConditionManager;
+    $this->couponManager = new CouponManager;
     $this->discountify = new Discountify(
         $this->conditionManager,
         $this->couponManager,
@@ -64,7 +64,7 @@ it('can set and get global discount', function () {
 
 it('sets the ConditionManager instance', function () {
 
-    $expextedResult = new ConditionManager();
+    $expextedResult = new ConditionManager;
     $this->discountify->setConditionManager($expextedResult);
 
     $conditionManager = $this->discountify->conditions();
@@ -75,7 +75,7 @@ it('sets the ConditionManager instance', function () {
 
 it('sets the CouponManager instance', function () {
 
-    $expextedResult = new CouponManager();
+    $expextedResult = new CouponManager;
     $this->discountify->setCouponManager($expextedResult);
 
     $couponManager = $this->discountify->coupons();

--- a/tests/DiscountifyTest.php
+++ b/tests/DiscountifyTest.php
@@ -24,13 +24,20 @@ beforeEach(function () {
         ['id' => '1', 'quantity' => 2, 'price' => 50],
         ['id' => '2', 'quantity' => 1, 'price' => 100],
     ];
-
+    $this->stateFilePath = workbench_path('app/test_state.json');
+    config(['discountify.state_file_path' => $this->stateFilePath]);
     $this->conditionManager = new ConditionManager();
     $this->couponManager = new CouponManager();
     $this->discountify = new Discountify(
         $this->conditionManager,
         $this->couponManager,
     );
+});
+
+afterEach(function () {
+    if (File::exists($this->stateFilePath)) {
+        File::delete($this->stateFilePath);
+    }
 });
 
 it('can set items', function () {

--- a/tests/HasStateTrackingTest.php
+++ b/tests/HasStateTrackingTest.php
@@ -10,7 +10,7 @@ use function Orchestra\Testbench\workbench_path;
 beforeEach(function () {
     $this->stateFilePath = workbench_path('app/test_state.json');
     config(['discountify.state_file_path' => $this->stateFilePath]);
-    $this->couponManager = new CouponManager();
+    $this->couponManager = new CouponManager;
 });
 
 afterEach(function () {
@@ -30,7 +30,7 @@ it('saves and loads coupons from the state file correctly', function () {
 
     $coupons = $this->couponManager->all();
 
-    $this->couponManager = new CouponManager();
+    $this->couponManager = new CouponManager;
 
     expect($this->couponManager->all())
         ->toEqual($coupons);

--- a/tests/HasStateTrackingTest.php
+++ b/tests/HasStateTrackingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Safemood\Discountify\CouponManager;
+
+use function Orchestra\Testbench\workbench_path;
+
+beforeEach(function () {
+    $this->stateFilePath = workbench_path('app/test_state.json');
+    config(['discountify.state_file_path' => $this->stateFilePath]);
+    $this->couponManager = new CouponManager();
+});
+
+afterEach(function () {
+    if (File::exists($this->stateFilePath)) {
+        File::delete($this->stateFilePath);
+    }
+});
+
+it('saves and loads coupons from the state file correctly', function () {
+
+    $this->couponManager->add([
+        'code' => 'PERIODLIMITED51',
+        'discount' => 50,
+        'startDate' => now(),
+        'endDate' => now()->addWeek(),
+    ]);
+
+    $coupons = $this->couponManager->all();
+
+    $this->couponManager = new CouponManager();
+
+    expect($this->couponManager->all())
+        ->toEqual($coupons);
+});


### PR DESCRIPTION
### PR Description

**Title:** Persistent State Management for Coupons

**Overview:**
This PR adds persistent state management for coupons, fixing issues with single-use and limited-use tracking.

**Changes:**
- Implemented saving and loading of coupon states to a JSON file.
- Added `setStateFilePath` to define the state file path.
- Added configuration for `state_file_path`, defaulting to `storage_path('app/discountify/coupons.json')`.
- Updated tests for single-use and limited-use coupons.

**Bug Fixes:**
- Ensured single-use and limited-use coupons from being reapplied across different instances.
- Preserved the state of single-use and limited-use coupons across instances.
